### PR TITLE
Fixed README.md to display correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 1. Run bower in same folder as your bower.json
 ``` bower install```
 1. Run bower-installer to get the key files into your app (i.e. src) folder
-``` bower-installer```
+``` bower-installer ```
 1.  Now look in app/ -- should see these folders which contain the bower managed dependencies
-  * app/js
-  * app/css
+    * app/js
+    * app/css
 1.  There's also a folder called bower_components which is the local copy of ALL the files for each dependency
 1.  Bower.json is the file that defines all this stuff (for more info read up on bower itself)
 1.  To add a new dependency to bower (e.g. fakerest)


### PR DESCRIPTION
![halbrook_github_readme](https://cloud.githubusercontent.com/assets/400979/12395366/2db6dda6-bdcf-11e5-8389-bfd3dad480bb.png)

README was not displaying correctly. (see above)  I used http://http://dillinger.io/ to test and it displayed the 'bower-installer' issue correctly, but the *app/js and *app/css not being indented, caused the numbering to start over at 1.  Not sure why it needed a space after 'installer ' in bower-installer ' to fix the issue, but it worked.  Also tabbing over the *app/js and *app/css fixed the number ordering.
